### PR TITLE
Develop - fix runtime issue when running CHBD and its variants with zero particles

### DIFF
--- a/src/particle_dynamics/PDApp.cpp
+++ b/src/particle_dynamics/PDApp.cpp
@@ -29,6 +29,9 @@ PDApp::PDApp(const GetPot& input_params)
     p.LY = p.NY*p.dy;
     p.LZ = p.NZ*p.dz;
 
+    // get number of particles to determin if greater than zero
+    numberOfParticles = input_params("PDApp/N",0);
+
     //	---------------------------------------
     //	Get some MPI parameters:
     //	---------------------------------------
@@ -111,5 +114,6 @@ void PDApp::stepForward(int step)
 void PDApp::writeOutput(int step)
 {
     pd_object->setTimeStep(step);
-    pd_object->outputParticles();
+    if(numberOfParticles > 0)
+        pd_object->outputParticles();
 }

--- a/src/particle_dynamics/PDApp.hpp
+++ b/src/particle_dynamics/PDApp.hpp
@@ -17,6 +17,7 @@ private:
 	int current_step;
 	CommonParams p;
 	PDParticles* pd_object;
+    int numberOfParticles; // for turning of output when N=0
 
 public:
 

--- a/src/phase_field/PFTypes/CHBD.cpp
+++ b/src/phase_field/PFTypes/CHBD.cpp
@@ -35,6 +35,7 @@ CHBD::CHBD(const CommonParams& pin,
     kap = input_params("PFApp/kap",1.0);
     part_step_skip = input_params("PFApp/part_step_skip",5);
     eCH = input_params("PFApp/eCH",0.0);
+    numberOfParticles = input_params("PDApp/N",0);
 
 }
 
@@ -164,9 +165,12 @@ void CHBD::outputPhaseField()
     int kskip = p.kskip;
     c1.writeVTKFile("c1",current_step,iskip,jskip,kskip);
     c2.writeVTKFile("c2",current_step,iskip,jskip,kskip);
-    cp.writeVTKFile("cp",current_step,iskip,jskip,kskip);
-    if (p.rank == 0) 
-        particles.outputParticles();
+    if (numberOfParticles > 0) // then write particle vtks
+    {
+        cp.writeVTKFile("cp",current_step,iskip,jskip,kskip);
+        if (p.rank == 0) 
+            particles.outputParticles();
+    }
 }
 
 

--- a/src/phase_field/PFTypes/CHBD.hpp
+++ b/src/phase_field/PFTypes/CHBD.hpp
@@ -17,6 +17,7 @@ class CHBD: public PFBaseClass {
         int current_step;
         int nxyz;
         int part_step_skip;
+        int numberOfParticles; //for turning off output when N=0
         Sfield c1;
         Sfield c2;
         Sfield cp;

--- a/src/phase_field/PFUtils/ParticlesBDCH.cpp
+++ b/src/phase_field/PFUtils/ParticlesBDCH.cpp
@@ -261,7 +261,8 @@ void ParticlesBDCH::calcCapillaryForce(const Sfield& cp,
         }
     }
     // Collect all capillary forces to MASTER
-    MPI::COMM_WORLD.Reduce(&fcap[0],&fcapSum[0],3*N,MPI::DOUBLE,MPI::SUM,0);
+    if (N>0)
+        MPI::COMM_WORLD.Reduce(&fcap[0],&fcapSum[0],3*N,MPI::DOUBLE,MPI::SUM,0);
     if (p.rank == 0) {
         for (int i=0; i<3*N; i++) fcap[i] = fcapSum[i];
     }


### PR DESCRIPTION
- CHBD and CHBDThinFilm now run with zero particles. They also do not output particle VTKs when running with zero particles.